### PR TITLE
Implementation of mean in categorical

### DIFF
--- a/tensorflow_probability/python/distributions/BUILD
+++ b/tensorflow_probability/python/distributions/BUILD
@@ -361,6 +361,7 @@ multi_substrate_py_library(
         "//tensorflow_probability/python/internal:reparameterization",
         "//tensorflow_probability/python/internal:tensor_util",
         "//tensorflow_probability/python/internal:tensorshape_util",
+        "//tensorflow_probability/python/math:generic",
     ],
 )
 

--- a/tensorflow_probability/python/distributions/categorical.py
+++ b/tensorflow_probability/python/distributions/categorical.py
@@ -30,6 +30,7 @@ from tensorflow_probability.python.internal import reparameterization
 from tensorflow_probability.python.internal import samplers
 from tensorflow_probability.python.internal import tensor_util
 from tensorflow_probability.python.internal import tensorshape_util
+from tensorflow_probability.python.math import reduce_weighted_logsumexp
 
 
 def _broadcast_cat_event_and_params(event, params, base_dtype):

--- a/tensorflow_probability/python/distributions/categorical.py
+++ b/tensorflow_probability/python/distributions/categorical.py
@@ -333,6 +333,10 @@ class Categorical(
         _mul_exp(log_probs, log_probs),
         axis=-1)
 
+  def _mean(self):
+    probs = self.probs_parameter()
+    return tf.reduce_sum(tf.range(self._num_categories(probs),dtype=probs.dtype) * probs, axis=-1) / tf.reduce_sum(probs, axis=-1)
+  
   def _mode(self):
     x = self._probs if self._logits is None else self._logits
     mode = tf.cast(tf.argmax(x, axis=-1), self.dtype)

--- a/tensorflow_probability/python/distributions/categorical.py
+++ b/tensorflow_probability/python/distributions/categorical.py
@@ -334,8 +334,11 @@ class Categorical(
         axis=-1)
 
   def _mean(self):
-    probs = self.probs_parameter()
-    return tf.reduce_sum(tf.range(self._num_categories(probs),dtype=probs.dtype) * probs, axis=-1) / tf.reduce_sum(probs, axis=-1)
+    #probs = self.probs_parameter()
+    #return tf.reduce_sum(tf.range(self._num_categories(probs),dtype=probs.dtype) * probs, axis=-1) / tf.reduce_sum(probs, axis=-1)
+    # Implement with logits to improve numerical stability
+    logits = self.logits_parameter()
+    return tf.math.exp(reduce_weighted_logsumexp(logits,w=tf.range(self._num_categories(logits),dtype=logits.dtype),axis=-1))
   
   def _mode(self):
     x = self._probs if self._logits is None else self._logits

--- a/tensorflow_probability/python/distributions/categorical.py
+++ b/tensorflow_probability/python/distributions/categorical.py
@@ -30,7 +30,7 @@ from tensorflow_probability.python.internal import reparameterization
 from tensorflow_probability.python.internal import samplers
 from tensorflow_probability.python.internal import tensor_util
 from tensorflow_probability.python.internal import tensorshape_util
-from tensorflow_probability.python.math import reduce_weighted_logsumexp
+from tensorflow_probability.python.math.generic import reduce_weighted_logsumexp
 
 
 def _broadcast_cat_event_and_params(event, params, base_dtype):

--- a/tensorflow_probability/python/distributions/categorical.py
+++ b/tensorflow_probability/python/distributions/categorical.py
@@ -335,11 +335,12 @@ class Categorical(
         axis=-1)
 
   def _mean(self):
-    #probs = self.probs_parameter()
-    #return tf.reduce_sum(tf.range(self._num_categories(probs),dtype=probs.dtype) * probs, axis=-1) / tf.reduce_sum(probs, axis=-1)
-    # Implement with logits to improve numerical stability
     logits = self.logits_parameter()
-    return tf.math.exp(reduce_weighted_logsumexp(logits,w=tf.range(self._num_categories(logits),dtype=logits.dtype),axis=-1))
+    return tf.math.exp(
+      reduce_weighted_logsumexp(
+        logits,
+        w=tf.range(self._num_categories(logits), dtype=logits.dtype),
+        axis=-1))
   
   def _mode(self):
     x = self._probs if self._logits is None else self._logits

--- a/tensorflow_probability/python/distributions/categorical_test.py
+++ b/tensorflow_probability/python/distributions/categorical_test.py
@@ -17,6 +17,7 @@
 # Dependency imports
 from absl.testing import parameterized
 import numpy as np
+from scipy import stats
 
 import tensorflow.compat.v1 as tf1
 import tensorflow.compat.v2 as tf
@@ -607,7 +608,7 @@ class CategoricalTest(test_util.TestCase):
     self.assertAllEqual((1,), dist.mean().shape)
     # Expected mean will be the same as in a Multinomial with n = 1
     expected_means = stats.multinomial.mean(n=1, p=p).argmax(axis=-1)
-    self.assertAllClose(expected_means, self.evaluate(binom.mean()))
+    self.assertAllClose(expected_means, self.evaluate(dist.mean()))
 
 
 @test_util.test_all_tf_execution_regimes

--- a/tensorflow_probability/python/distributions/categorical_test.py
+++ b/tensorflow_probability/python/distributions/categorical_test.py
@@ -598,6 +598,16 @@ class CategoricalTest(test_util.TestCase):
     self.assertAllClose(
         *self.evaluate([x, d.probs_parameter()]),
         atol=0, rtol=1e-4)
+    
+    
+  def testCategoricalMean(self):
+    p = [0.2, 0.75, 0.05, 0.]
+    dist = categorical.Categorical(probs=p, validate_args=True)
+    # Mean will be broadcast to a singleton dimension 
+    self.assertAllEqual((1,), dist.mean().shape)
+    # Expected mean will be the same as in a Multinomial with n = 1
+    expected_means = stats.multinomial.mean(n=1, p=p).argmax(axis=-1)
+    self.assertAllClose(expected_means, self.evaluate(binom.mean()))
 
 
 @test_util.test_all_tf_execution_regimes


### PR DESCRIPTION
Implementation of the mean method in the Categorical distribution. The implementation was based on this code:
```python
  def _mean(self):
    probs = self.probs_parameter()
    num_categories = self._num_categories(probs)
    # Initialise the mean with zeros
    categorical_mean = tf.zeros(tf.shape(probs[...,0]))
    # Compute the normalisation factors such that all probabilities sum up to 1
    normalisation = tf.reduce_sum(probs, axis=-1)
    # Sum up all the normalised probabilities
    # sum(i * prob(X=i) for i in range(num_categories) )
    for i in range(num_categories):
    	categorical_mean = categorical_mean + tf.cast(i,probs.dtype) * probs[...,i] / normalisation
    
    return categorical_mean
``` 